### PR TITLE
Add workaround for Veryl v0.18.0

### DIFF
--- a/rggen_apb_adapter.veryl
+++ b/rggen_apb_adapter.veryl
@@ -17,10 +17,11 @@ pub module rggen_apb_adapter #(
   apb_if:       modport rggen_apb_if::slave,
   register_if:  modport rggen_register_if::host[REGISTERS]
 ) {
-  inst  bus_if:   rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
-  var   pready:   logic;
-  var   prdata:   logic<BUS_WIDTH>;
-  var   pslverr:  logic;
+  inst  bus_if : rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
+  var   bus_ack: logic;
+  var   pready : logic;
+  var   prdata : logic<BUS_WIDTH>;
+  var   pslverr: logic;
 
   always_comb {
     bus_if.valid      = apb_if.psel && (!pready);
@@ -44,8 +45,12 @@ pub module rggen_apb_adapter #(
     }
   }
 
+  always_comb {
+    bus_ack = bus_if.ack();
+  }
+
   always_ff {
-    if bus_if.ack() {
+    if bus_ack {
       prdata  = bus_if.read_data;
       pslverr = bus_if.status[1];
     }

--- a/rggen_avalon_adapter.veryl
+++ b/rggen_avalon_adapter.veryl
@@ -17,10 +17,11 @@ pub module rggen_avalon_adapter #(
   avalon_if:    modport rggen_avalon_if::agent,
   register_if:  modport rggen_register_if::host[REGISTERS]
 ) {
-  inst  bus_if:       rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
-  var   waitrequest:  logic;
-  var   response:     logic<2>;
-  var   readdata:     logic<BUS_WIDTH>;
+  inst  bus_if     : rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
+  var   bus_ack    : logic;
+  var   waitrequest: logic;
+  var   response   : logic<2>;
+  var   readdata   : logic<BUS_WIDTH>;
 
   always_comb {
     bus_if.valid      = (avalon_if.read || avalon_if.write) && waitrequest;
@@ -46,8 +47,12 @@ pub module rggen_avalon_adapter #(
     }
   }
 
+  always_comb {
+    bus_ack = bus_if.ack();
+  }
+
   always_ff {
-    if bus_if.ack() {
+    if bus_ack {
       response  = bus_if.status;
       readdata  = bus_if.read_data;
     }

--- a/rggen_axi4lite_adapter.veryl
+++ b/rggen_axi4lite_adapter.veryl
@@ -19,13 +19,14 @@ pub module rggen_axi4lite_adapter #(
   axi4lite_if:  modport rggen_axi4lite_if::slave,
   register_if:  modport rggen_register_if::host[REGISTERS]
 ) {
-  inst  buffer_if:      rggen_axi4lite_if #(ID_WIDTH, ADDRESS_WIDTH, BUS_WIDTH);
-  inst  bus_if:         rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
-  var   request_valid:  logic<2, 2>;
+  inst  buffer_if     : rggen_axi4lite_if #(ID_WIDTH, ADDRESS_WIDTH, BUS_WIDTH);
+  inst  bus_if        : rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
+  var   bus_ack       : logic;
+  var   request_valid : logic<2, 2>;
   var   response_valid: logic<2>;
-  var   id:             logic<clip_width(ID_WIDTH)>;
-  var   read_data:      logic<BUS_WIDTH>;
-  var   status:         logic<2>;
+  var   id            : logic<clip_width(ID_WIDTH)>;
+  var   read_data     : logic<BUS_WIDTH>;
+  var   status        : logic<2>;
 
   //  Skid buffer
   inst u_buffer: rggen_axi4lite_skid_buffer #(
@@ -137,8 +138,12 @@ pub module rggen_axi4lite_adapter #(
     assign  id  = '0;
   }
 
+  always_comb {
+    bus_ack = bus_if.ack();
+  }
+
   always_ff {
-    if bus_if.ack() {
+    if bus_ack {
       status    = bus_if.status;
       read_data = bus_if.read_data;
     }

--- a/rggen_native_adapter.veryl
+++ b/rggen_native_adapter.veryl
@@ -19,9 +19,10 @@ pub module rggen_native_adapter #(
   csrbus_if:    modport rggen_bus_if::slave,
   register_if:  modport rggen_register_if::host[REGISTERS]
 ) {
-  inst  bus_if:           rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH, STROBE_WIDTH);
-  var   csrbus_ready:     logic;
-  var   csrbus_status:    rggen_status;
+  inst  bus_if          : rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH, STROBE_WIDTH);
+  var   bus_ack         : logic;
+  var   csrbus_ready    : logic;
+  var   csrbus_status   : rggen_status;
   var   csrbus_read_data: logic<BUS_WIDTH>;
 
   always_comb {
@@ -46,8 +47,12 @@ pub module rggen_native_adapter #(
     }
   }
 
+  always_comb {
+    bus_ack = bus_if.ack();
+  }
+
   always_ff {
-    if bus_if.ack() {
+    if bus_ack {
       csrbus_status     = bus_if.status;
       csrbus_read_data  = bus_if.read_data;
     }

--- a/rggen_rtl_pkg.veryl
+++ b/rggen_rtl_pkg.veryl
@@ -12,17 +12,17 @@ pub package rggen_rtl_pkg {
     DECODE_ERROR  = 2'b11
   }
 
-  enum rggen_sw_hw_access {
+  enum rggen_sw_hw_access: bit {
     SW_ACCESS,
     HW_ACCESS
   }
 
-  enum rggen_polarity {
+  enum rggen_polarity: bit {
     ACTIVE_LOW,
     ACTIVE_HIGH
   }
 
-  enum rggen_sw_action {
+  enum rggen_sw_action: bit<4> {
     READ_NONE,
     READ_DEFAULT,
     READ_CLEAR,

--- a/rggen_wishbone_adapter.veryl
+++ b/rggen_wishbone_adapter.veryl
@@ -18,14 +18,15 @@ pub module rggen_wishbone_adapter #(
   wishbone_if:  modport rggen_wishbone_if::slave,
   register_if:  modport rggen_register_if::host[REGISTERS]
 ) {
-  inst  bus_if:         rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
-  var   request_valid:  logic<2>;
-  var   wb_adr:         logic<ADDRESS_WIDTH>;
-  var   wb_we:          logic;
-  var   wb_dat:         logic<BUS_WIDTH>;
-  var   wb_sel:         logic<BUS_WIDTH/8>;
+  inst  bus_if        : rggen_bus_if #(ADDRESS_WIDTH, BUS_WIDTH);
+  var   bus_ack       : logic;
+  var   request_valid : logic<2>;
+  var   wb_adr        : logic<ADDRESS_WIDTH>;
+  var   wb_we         : logic;
+  var   wb_dat        : logic<BUS_WIDTH>;
+  var   wb_sel        : logic<BUS_WIDTH/8>;
   var   response_valid: logic<2>;
-  var   response_data:  logic<BUS_WIDTH>;
+  var   response_data : logic<BUS_WIDTH>;
 
   //  Request
   always_comb {
@@ -93,12 +94,16 @@ pub module rggen_wishbone_adapter #(
     wishbone_if.dat_r = response_data;
   }
 
+  always_comb {
+    bus_ack = bus_if.ack();
+  }
+
   always_ff {
     if_reset {
       response_valid  = '0;
     } else if response_valid != '0 {
       response_valid  = '0;
-    } else if bus_if.ack() {
+    } else if bus_ack {
       case bus_if.status {
         rggen_status::OKAY,
         rggen_status::EXOKAY: response_valid  = 2'b01;
@@ -108,7 +113,7 @@ pub module rggen_wishbone_adapter #(
   }
 
   always_ff {
-    if bus_if.ack() {
+    if bus_ack {
       response_data = bus_if.read_data;
     }
   }


### PR DESCRIPTION
Following warnings are reported when checking source files with Veryl v0.18.0.

```
Warning: mismatch_assignment (link)

  ⚠ "logic<1>" can't be assigned to "bit<1>"
    ╭─[/home/taichi/workspace/rggen/rggen-veryl-rtl/rggen_bit_field.veryl:38:33]
 37 │ ) {
 38 │   const SW_WRITABLE   : bbool = SW_WRITE_ACTION != rggen_sw_action::WRITE_NONE;
    ·                                 ───────────────────────┬──────────────────────
    ·                                                        ╰── Error location
 39 │   const SW_READABLE   : bbool = SW_READ_ACTION  != rggen_sw_action::READ_NONE;
    ╰────
  help: 
```

```
Warning: unassign_variable (link)

  ⚠ "status" is unassigned
    ╭─[/home/taichi/workspace/rggen/rggen-veryl-rtl/rggen_axi4lite_adapter.veryl:28:9]
 27 │   var   read_data:      logic<BUS_WIDTH>;
 28 │   var   status:         logic<2>;
    ·         ───┬──
    ·            ╰── Error location
 29 │ 
    ╰────
  help: 
```

This PR is to apply workaround for the above warnings.